### PR TITLE
test(mlx-core): memoization of realized nodes

### DIFF
--- a/crates/mlx-core/src/backend.rs
+++ b/crates/mlx-core/src/backend.rs
@@ -289,6 +289,8 @@ mod tests {
 
         stream.eval(out).unwrap();
         let after_first = calls.load(Ordering::Relaxed);
+        assert_eq!(after_first, 2);
+        assert_eq!(stream.get_buffer(out).unwrap(), vec![-4.0, -6.0]);
 
         // Repeated eval should not call into the backend again.
         stream.eval(out).unwrap();


### PR DESCRIPTION
Fixes #22

Adds a regression test that verifies Stream/Tensor eval() memoizes realized nodes:
- backend eval_node() call count stays constant across repeated eval() calls
- already-materialized intermediates also do not trigger recompute
