### PR TITLE
fix: address PR #62 review feedback (broadcast VJP bug + safety docs)

### DIFF
--- a/crates/mlx-nn/src/norm.rs
+++ b/crates/mlx-nn/src/norm.rs
@@ -9,6 +9,7 @@ use crate::Module;
 /// Normalizes to zero mean and unit variance, controlled by `eps` for
 /// numerical stability.
 pub struct LayerNorm {
+    /// Reserved for learnable scale/shift parameters (Phase 2).
     #[allow(dead_code)]
     dim: usize,
     eps: f32,
@@ -31,6 +32,7 @@ impl Module for LayerNorm {
 /// Like LayerNorm but skips the mean-centering step, normalizing only by
 /// the root-mean-square.
 pub struct RmsNorm {
+    /// Reserved for learnable scale parameter (Phase 2).
     #[allow(dead_code)]
     dim: usize,
     eps: f32,

--- a/crates/mlx-ops/src/dtype_promotion.rs
+++ b/crates/mlx-ops/src/dtype_promotion.rs
@@ -22,7 +22,7 @@ pub fn promote(a: DType, b: DType) -> DType {
 }
 
 /// Numeric priority for dtype promotion (higher = wider).
-fn priority(dt: DType) -> u8 {
+pub fn priority(dt: DType) -> u8 {
     match dt {
         DType::I32 => 1,
         DType::I64 => 2,

--- a/crates/mlx-ops/tests/proptest_shapes.rs
+++ b/crates/mlx-ops/tests/proptest_shapes.rs
@@ -53,18 +53,7 @@ fn arb_dtype() -> impl Strategy<Value = DType> {
     ]
 }
 
-/// Numeric priority for dtype promotion (higher = wider).
-///
-/// Keep in sync with `crates/mlx-ops/src/dtype_promotion.rs`.
-fn dtype_priority(dt: DType) -> u8 {
-    match dt {
-        DType::I32 => 1,
-        DType::I64 => 2,
-        DType::F16 => 3,
-        DType::BF16 => 4,
-        DType::F32 => 5,
-    }
-}
+use mlx_ops::dtype_promotion::priority as dtype_priority;
 
 /// Generate a 2D shape for matmul.
 fn matmul_shapes() -> impl Strategy<Value = (Shape, Shape)> {

--- a/crates/mlx-sys/src/native_impl.rs
+++ b/crates/mlx-sys/src/native_impl.rs
@@ -24,6 +24,11 @@ fn box_tensor(t: Tensor) -> *mut mlx_tensor_t {
     Box::into_raw(Box::new(t)) as *mut mlx_tensor_t
 }
 
+/// # Safety
+///
+/// `p` must be a valid pointer obtained from `box_tensor` that has not been freed.
+/// The returned reference is valid only as long as `p` is live — callers must not
+/// use the reference after calling `mlxrs_free_tensor(p)`.
 unsafe fn ref_tensor<'a>(p: *mut mlx_tensor_t) -> &'a Tensor {
     unsafe { &*(p as *const Tensor) }
 }
@@ -32,6 +37,11 @@ fn box_device(d: Device) -> *mut mlx_device_t {
     Box::into_raw(Box::new(d)) as *mut mlx_device_t
 }
 
+/// # Safety
+///
+/// `p` must be a valid pointer obtained from `box_device` that has not been freed.
+/// The returned reference is valid only as long as `p` is live — callers must not
+/// use the reference after calling `mlxrs_free_device(p)`.
 unsafe fn ref_device<'a>(p: *mut mlx_device_t) -> &'a Device {
     unsafe { &*(p as *const Device) }
 }


### PR DESCRIPTION
## Summary
- **Fix broadcast VJP bug**: `sum_axis` on a 1-D tensor yields shape `[1]` instead of `[]`, causing the reshape to incorrectly inflate the shape (e.g., `[1]` became `[1, 1]`). Now checks if ndim actually decreased before re-inserting the reduced dimension.
- **Add 4 broadcast VJP tests**: rank extension (`[3]`→`[2,3]`), dimension expansion (`[1,3]`→`[2,3]`), combined (`[1,3]`→`[4,2,3]`), and scalar broadcast (`[1]`→`[2,3]`).
- **Deduplicate dtype_priority**: export `priority()` from `dtype_promotion` module; proptest now imports it instead of maintaining a copy.
- **Add safety docs** on `ref_tensor`/`ref_device` in `mlx-sys` explaining lifetime invariants.
- **Add TODO comments** on unused `dim` fields in LayerNorm/RmsNorm.

Addresses all 6 Copilot review comments from PR #62 (develop → main merge).

## Test plan
- [x] `cargo test -p mlx-autograd` — 22 passed (4 new broadcast VJP tests)
- [x] `cargo test -p mlx-ops --test proptest_shapes` — 20 passed
- [x] `cargo clippy -p mlx-autograd -p mlx-nn -p mlx-ops -p mlx-sys -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)