### PR TITLE
bench: expand criterion coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ dependencies = [
 name = "mlx-core"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "smallvec",
  "thiserror",
 ]

--- a/crates/mlx-core/Cargo.toml
+++ b/crates/mlx-core/Cargo.toml
@@ -8,3 +8,22 @@ description = "Safe Rust API for MLX tensors, devices, and core operations"
 [dependencies]
 thiserror.workspace = true
 smallvec.workspace = true
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "matmul"
+harness = false
+
+[[bench]]
+name = "reductions"
+harness = false
+
+[[bench]]
+name = "norm"
+harness = false
+
+[[bench]]
+name = "rope"
+harness = false

--- a/crates/mlx-core/benches/matmul.rs
+++ b/crates/mlx-core/benches/matmul.rs
@@ -1,0 +1,64 @@
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use mlx_core::backend::Stream;
+use mlx_core::cpu_kernels::CpuRefBackend;
+use mlx_core::graph::{OpKind, TensorMeta};
+use mlx_core::types::{DType, Shape};
+use smallvec::SmallVec;
+
+fn bench_matmul(c: &mut Criterion) {
+    let shapes: &[(usize, usize, usize, &str)] = &[
+        (1, 256, 256, "decode_1x256x256"),
+        (32, 256, 256, "prefill_32x256x256"),
+        (64, 512, 512, "mid_64x512x512"),
+    ];
+
+    let mut group = c.benchmark_group("cpu_matmul_f32");
+
+    for &(m, k, n, name) in shapes {
+        let flops = 2 * m * k * n;
+        group.throughput(Throughput::Elements(flops as u64));
+
+        let a_data: Vec<f32> = (0..m * k).map(|i| (i as f32) * 0.001).collect();
+        let b_data: Vec<f32> = (0..k * n).map(|i| (i as f32) * 0.001).collect();
+
+        group.bench_function(BenchmarkId::new("matmul", name), |bench| {
+            bench.iter_batched(
+                || {
+                    let stream = Stream::new(Box::new(CpuRefBackend));
+                    let a = stream.add_constant(
+                        a_data.clone(),
+                        TensorMeta {
+                            shape: Shape::new(vec![m as i64, k as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    let b = stream.add_constant(
+                        b_data.clone(),
+                        TensorMeta {
+                            shape: Shape::new(vec![k as i64, n as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    (stream, a, b)
+                },
+                |(stream, a, b)| {
+                    let c = stream.add_op(
+                        OpKind::MatMul,
+                        SmallVec::from_slice(&[a, b]),
+                        TensorMeta {
+                            shape: Shape::new(vec![m as i64, n as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    stream.eval(c).expect("matmul eval");
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_matmul);
+criterion_main!(benches);

--- a/crates/mlx-core/benches/norm.rs
+++ b/crates/mlx-core/benches/norm.rs
@@ -1,0 +1,82 @@
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use mlx_core::backend::Stream;
+use mlx_core::cpu_kernels::CpuRefBackend;
+use mlx_core::graph::{OpKind, TensorMeta};
+use mlx_core::types::{DType, Shape};
+use smallvec::SmallVec;
+
+fn bench_norm(c: &mut Criterion) {
+    let shapes: &[(usize, usize, &str)] = &[
+        (128, 256, "128x256"),
+        (256, 512, "256x512"),
+        (512, 1024, "512x1024"),
+    ];
+
+    let mut group = c.benchmark_group("cpu_norm_f32");
+
+    for &(tokens, dim, name) in shapes {
+        let numel = tokens * dim;
+        let x_data: Vec<f32> = (0..numel).map(|i| (i as f32) * 0.001).collect();
+
+        group.bench_function(BenchmarkId::new("layer_norm", name), |bench| {
+            bench.iter_batched(
+                || {
+                    let stream = Stream::new(Box::new(CpuRefBackend));
+                    let x = stream.add_constant(
+                        x_data.clone(),
+                        TensorMeta {
+                            shape: Shape::new(vec![tokens as i64, dim as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    (stream, x)
+                },
+                |(stream, x)| {
+                    let y = stream.add_op(
+                        OpKind::LayerNorm { eps: 1e-5 },
+                        SmallVec::from_slice(&[x]),
+                        TensorMeta {
+                            shape: Shape::new(vec![tokens as i64, dim as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    stream.eval(y).expect("layer_norm eval");
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("rms_norm", name), |bench| {
+            bench.iter_batched(
+                || {
+                    let stream = Stream::new(Box::new(CpuRefBackend));
+                    let x = stream.add_constant(
+                        x_data.clone(),
+                        TensorMeta {
+                            shape: Shape::new(vec![tokens as i64, dim as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    (stream, x)
+                },
+                |(stream, x)| {
+                    let y = stream.add_op(
+                        OpKind::RmsNorm { eps: 1e-5 },
+                        SmallVec::from_slice(&[x]),
+                        TensorMeta {
+                            shape: Shape::new(vec![tokens as i64, dim as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    stream.eval(y).expect("rms_norm eval");
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_norm);
+criterion_main!(benches);

--- a/crates/mlx-core/benches/reductions.rs
+++ b/crates/mlx-core/benches/reductions.rs
@@ -1,0 +1,82 @@
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use mlx_core::backend::Stream;
+use mlx_core::cpu_kernels::CpuRefBackend;
+use mlx_core::graph::{OpKind, TensorMeta};
+use mlx_core::types::{DType, Shape};
+use smallvec::SmallVec;
+
+fn bench_reductions(c: &mut Criterion) {
+    let shapes: &[(usize, usize, &str)] = &[
+        (128, 128, "128x128"),
+        (256, 256, "256x256"),
+        (512, 512, "512x512"),
+    ];
+
+    let mut group = c.benchmark_group("cpu_reductions_f32");
+
+    for &(m, n, name) in shapes {
+        let numel = m * n;
+        let x_data: Vec<f32> = (0..numel).map(|i| (i as f32) * 0.001).collect();
+
+        group.bench_function(BenchmarkId::new("sum_all", name), |bench| {
+            bench.iter_batched(
+                || {
+                    let stream = Stream::new(Box::new(CpuRefBackend));
+                    let x = stream.add_constant(
+                        x_data.clone(),
+                        TensorMeta {
+                            shape: Shape::new(vec![m as i64, n as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    (stream, x)
+                },
+                |(stream, x)| {
+                    let y = stream.add_op(
+                        OpKind::Sum { axis: None },
+                        SmallVec::from_slice(&[x]),
+                        TensorMeta {
+                            shape: Shape::new(vec![1]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    stream.eval(y).expect("sum_all eval");
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("sum_axis1", name), |bench| {
+            bench.iter_batched(
+                || {
+                    let stream = Stream::new(Box::new(CpuRefBackend));
+                    let x = stream.add_constant(
+                        x_data.clone(),
+                        TensorMeta {
+                            shape: Shape::new(vec![m as i64, n as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    (stream, x)
+                },
+                |(stream, x)| {
+                    let y = stream.add_op(
+                        OpKind::Sum { axis: Some(1) },
+                        SmallVec::from_slice(&[x]),
+                        TensorMeta {
+                            shape: Shape::new(vec![m as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    stream.eval(y).expect("sum_axis eval");
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_reductions);
+criterion_main!(benches);

--- a/crates/mlx-core/benches/rope.rs
+++ b/crates/mlx-core/benches/rope.rs
@@ -1,0 +1,58 @@
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use mlx_core::backend::Stream;
+use mlx_core::cpu_kernels::CpuRefBackend;
+use mlx_core::graph::{OpKind, TensorMeta};
+use mlx_core::types::{DType, Shape};
+use smallvec::SmallVec;
+
+fn bench_rope(c: &mut Criterion) {
+    let shapes: &[(usize, usize, usize, &str)] = &[
+        (128, 128, 128, "128x128"),
+        (256, 128, 128, "256x128"),
+        (512, 64, 64, "512x64"),
+    ];
+
+    let mut group = c.benchmark_group("cpu_rope_f32");
+
+    for &(tokens, head_dim, rotary_dim, name) in shapes {
+        let numel = tokens * head_dim;
+        let x_data: Vec<f32> = (0..numel).map(|i| (i as f32) * 0.001).collect();
+
+        group.bench_function(BenchmarkId::new("rope", name), |bench| {
+            bench.iter_batched(
+                || {
+                    let stream = Stream::new(Box::new(CpuRefBackend));
+                    let x = stream.add_constant(
+                        x_data.clone(),
+                        TensorMeta {
+                            shape: Shape::new(vec![tokens as i64, head_dim as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    (stream, x)
+                },
+                |(stream, x)| {
+                    let y = stream.add_op(
+                        OpKind::Rope {
+                            rotary_dim,
+                            pos_offset: 0,
+                            theta: 10000.0,
+                        },
+                        SmallVec::from_slice(&[x]),
+                        TensorMeta {
+                            shape: Shape::new(vec![tokens as i64, head_dim as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    stream.eval(y).expect("rope eval");
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_rope);
+criterion_main!(benches);

--- a/crates/mlx-metal/Cargo.toml
+++ b/crates/mlx-metal/Cargo.toml
@@ -27,3 +27,15 @@ tracing-subscriber = { workspace = true }
 [[bench]]
 name = "gemm"
 harness = false
+
+[[bench]]
+name = "reductions"
+harness = false
+
+[[bench]]
+name = "norm"
+harness = false
+
+[[bench]]
+name = "rope"
+harness = false

--- a/crates/mlx-metal/benches/norm.rs
+++ b/crates/mlx-metal/benches/norm.rs
@@ -1,0 +1,87 @@
+#[cfg(target_os = "macos")]
+use criterion::{BatchSize, BenchmarkId};
+use criterion::{Criterion, criterion_group, criterion_main};
+#[cfg(target_os = "macos")]
+use mlx_core::graph::{OpKind, TensorMeta};
+#[cfg(target_os = "macos")]
+use mlx_core::types::{DType, Shape};
+
+#[cfg(target_os = "macos")]
+fn bench_norm(c: &mut Criterion) {
+    let shapes: &[(usize, usize, &str)] = &[
+        (128, 256, "128x256"),
+        (256, 512, "256x512"),
+        (512, 1024, "512x1024"),
+    ];
+
+    let mut group = c.benchmark_group("metal_norm_f32");
+
+    for &(tokens, dim, name) in shapes {
+        let numel = tokens * dim;
+        let x_data: Vec<f32> = (0..numel).map(|i| (i as f32) * 0.001).collect();
+
+        group.bench_function(BenchmarkId::new("layer_norm", name), |bench| {
+            bench.iter_batched(
+                || {
+                    let stream = mlx_metal::metal_stream().expect("Metal should be available");
+                    let x = stream.add_constant(
+                        x_data.clone(),
+                        TensorMeta {
+                            shape: Shape::new(vec![tokens as i64, dim as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    (stream, x)
+                },
+                |(stream, x)| {
+                    let y = stream.add_op(
+                        OpKind::LayerNorm { eps: 1e-5 },
+                        smallvec::SmallVec::from_slice(&[x]),
+                        TensorMeta {
+                            shape: Shape::new(vec![tokens as i64, dim as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    stream.eval(y).expect("layer_norm eval");
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("rms_norm", name), |bench| {
+            bench.iter_batched(
+                || {
+                    let stream = mlx_metal::metal_stream().expect("Metal should be available");
+                    let x = stream.add_constant(
+                        x_data.clone(),
+                        TensorMeta {
+                            shape: Shape::new(vec![tokens as i64, dim as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    (stream, x)
+                },
+                |(stream, x)| {
+                    let y = stream.add_op(
+                        OpKind::RmsNorm { eps: 1e-5 },
+                        smallvec::SmallVec::from_slice(&[x]),
+                        TensorMeta {
+                            shape: Shape::new(vec![tokens as i64, dim as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    stream.eval(y).expect("rms_norm eval");
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "macos"))]
+fn bench_norm(_c: &mut Criterion) {}
+
+criterion_group!(benches, bench_norm);
+criterion_main!(benches);

--- a/crates/mlx-metal/benches/reductions.rs
+++ b/crates/mlx-metal/benches/reductions.rs
@@ -1,0 +1,87 @@
+#[cfg(target_os = "macos")]
+use criterion::{BatchSize, BenchmarkId};
+use criterion::{Criterion, criterion_group, criterion_main};
+#[cfg(target_os = "macos")]
+use mlx_core::graph::{OpKind, TensorMeta};
+#[cfg(target_os = "macos")]
+use mlx_core::types::{DType, Shape};
+
+#[cfg(target_os = "macos")]
+fn bench_reductions(c: &mut Criterion) {
+    let shapes: &[(usize, usize, &str)] = &[
+        (128, 128, "128x128"),
+        (256, 256, "256x256"),
+        (512, 512, "512x512"),
+    ];
+
+    let mut group = c.benchmark_group("metal_reductions_f32");
+
+    for &(m, n, name) in shapes {
+        let numel = m * n;
+        let x_data: Vec<f32> = (0..numel).map(|i| (i as f32) * 0.001).collect();
+
+        group.bench_function(BenchmarkId::new("sum_all", name), |bench| {
+            bench.iter_batched(
+                || {
+                    let stream = mlx_metal::metal_stream().expect("Metal should be available");
+                    let x = stream.add_constant(
+                        x_data.clone(),
+                        TensorMeta {
+                            shape: Shape::new(vec![m as i64, n as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    (stream, x)
+                },
+                |(stream, x)| {
+                    let y = stream.add_op(
+                        OpKind::Sum { axis: None },
+                        smallvec::SmallVec::from_slice(&[x]),
+                        TensorMeta {
+                            shape: Shape::new(vec![1]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    stream.eval(y).expect("sum_all eval");
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("sum_axis1", name), |bench| {
+            bench.iter_batched(
+                || {
+                    let stream = mlx_metal::metal_stream().expect("Metal should be available");
+                    let x = stream.add_constant(
+                        x_data.clone(),
+                        TensorMeta {
+                            shape: Shape::new(vec![m as i64, n as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    (stream, x)
+                },
+                |(stream, x)| {
+                    let y = stream.add_op(
+                        OpKind::Sum { axis: Some(1) },
+                        smallvec::SmallVec::from_slice(&[x]),
+                        TensorMeta {
+                            shape: Shape::new(vec![m as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    stream.eval(y).expect("sum_axis eval");
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "macos"))]
+fn bench_reductions(_c: &mut Criterion) {}
+
+criterion_group!(benches, bench_reductions);
+criterion_main!(benches);

--- a/crates/mlx-metal/benches/rope.rs
+++ b/crates/mlx-metal/benches/rope.rs
@@ -1,0 +1,63 @@
+#[cfg(target_os = "macos")]
+use criterion::{BatchSize, BenchmarkId};
+use criterion::{Criterion, criterion_group, criterion_main};
+#[cfg(target_os = "macos")]
+use mlx_core::graph::{OpKind, TensorMeta};
+#[cfg(target_os = "macos")]
+use mlx_core::types::{DType, Shape};
+
+#[cfg(target_os = "macos")]
+fn bench_rope(c: &mut Criterion) {
+    let shapes: &[(usize, usize, usize, &str)] = &[
+        (128, 128, 128, "128x128"),
+        (256, 128, 128, "256x128"),
+        (512, 64, 64, "512x64"),
+    ];
+
+    let mut group = c.benchmark_group("metal_rope_f32");
+
+    for &(tokens, head_dim, rotary_dim, name) in shapes {
+        let numel = tokens * head_dim;
+        let x_data: Vec<f32> = (0..numel).map(|i| (i as f32) * 0.001).collect();
+
+        group.bench_function(BenchmarkId::new("rope", name), |bench| {
+            bench.iter_batched(
+                || {
+                    let stream = mlx_metal::metal_stream().expect("Metal should be available");
+                    let x = stream.add_constant(
+                        x_data.clone(),
+                        TensorMeta {
+                            shape: Shape::new(vec![tokens as i64, head_dim as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    (stream, x)
+                },
+                |(stream, x)| {
+                    let y = stream.add_op(
+                        OpKind::Rope {
+                            rotary_dim,
+                            pos_offset: 0,
+                            theta: 10000.0,
+                        },
+                        smallvec::SmallVec::from_slice(&[x]),
+                        TensorMeta {
+                            shape: Shape::new(vec![tokens as i64, head_dim as i64]),
+                            dtype: DType::F32,
+                        },
+                    );
+                    stream.eval(y).expect("rope eval");
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "macos"))]
+fn bench_rope(_c: &mut Criterion) {}
+
+criterion_group!(benches, bench_rope);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- Add Criterion benchmarks for CPU backend: matmul, reductions (sum_all, sum_axis), normalization (layer_norm, rms_norm), and RoPE
- Add Criterion benchmarks for Metal backend: GEMM, reductions, normalization, and RoPE
- Add criterion dev-dependency to mlx-core

Rebased onto develop — removed stale non-bench changes (Exp/Log, RoPE naming, OpKey formatting) that were already merged.

## Test plan
- [x] `cargo check -p mlx-core --benches` compiles
- [x] `cargo check -p mlx-metal --benches` compiles
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test -p mlx-core -p mlx-ops -p mlx-autograd` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)