### PR TITLE
fix(graph): disable CSE for constants to prevent gradient aliasing

### DIFF
--- a/crates/mlx-core/src/graph.rs
+++ b/crates/mlx-core/src/graph.rs
@@ -326,16 +326,42 @@ enum OpKey {
     },
     Silu,
     Gelu,
-    LayerNorm { eps_bits: u32 },
-    RmsNorm { eps_bits: u32 },
-    Broadcast { target_shape: Vec<i64> },
-    LayerNormVjp { eps_bits: u32 },
-    RmsNormVjp { eps_bits: u32 },
-    ScaledMaskedSoftmax { scale_bits: u32, causal: bool },
-    Attention { scale_bits: u32, causal: bool },
-    Rope { rotary_dim: usize, pos_offset: usize, theta_bits: u32 },
-    RoPE { base_bits: u32, offset: usize, traditional: bool },
-    SoftmaxVjp { axis: i32 },
+    LayerNorm {
+        eps_bits: u32,
+    },
+    RmsNorm {
+        eps_bits: u32,
+    },
+    Broadcast {
+        target_shape: Vec<i64>,
+    },
+    LayerNormVjp {
+        eps_bits: u32,
+    },
+    RmsNormVjp {
+        eps_bits: u32,
+    },
+    ScaledMaskedSoftmax {
+        scale_bits: u32,
+        causal: bool,
+    },
+    Attention {
+        scale_bits: u32,
+        causal: bool,
+    },
+    Rope {
+        rotary_dim: usize,
+        pos_offset: usize,
+        theta_bits: u32,
+    },
+    RoPE {
+        base_bits: u32,
+        offset: usize,
+        traditional: bool,
+    },
+    SoftmaxVjp {
+        axis: i32,
+    },
     SiluVjp,
     GeluVjp,
     Sqrt,
@@ -385,12 +411,20 @@ impl OpKey {
                 scale_bits: scale.to_bits(),
                 causal: *causal,
             },
-            OpKind::Rope { rotary_dim, pos_offset, theta } => OpKey::Rope {
+            OpKind::Rope {
+                rotary_dim,
+                pos_offset,
+                theta,
+            } => OpKey::Rope {
                 rotary_dim: *rotary_dim,
                 pos_offset: *pos_offset,
                 theta_bits: theta.to_bits(),
             },
-            OpKind::RoPE { base, offset, traditional } => OpKey::RoPE {
+            OpKind::RoPE {
+                base,
+                offset,
+                traditional,
+            } => OpKey::RoPE {
                 base_bits: base.to_bits(),
                 offset: *offset,
                 traditional: *traditional,
@@ -412,7 +446,10 @@ struct CseKey {
 }
 
 fn is_cse_eligible(op: &OpKind) -> bool {
-    !matches!(op, OpKind::Parameter)
+    // Constants and Parameters must never be deduplicated: two tensors with
+    // identical data may flow through different parts of the graph and receive
+    // independent gradients during backpropagation.
+    !matches!(op, OpKind::Constant | OpKind::Parameter)
 }
 
 pub fn hash_f32_payload(data: &[f32]) -> u64 {
@@ -473,7 +510,32 @@ mod tests {
     }
 
     #[test]
-    fn test_cse_dedups_constants_and_ops() {
+    fn test_cse_does_not_dedup_constants() {
+        let mut g = Graph::new();
+        let meta = TensorMeta {
+            shape: Shape::new(vec![2]),
+            dtype: DType::F32,
+        };
+        // Constants must NOT be deduplicated — they may receive independent
+        // gradients during backpropagation.
+        let a = g.intern_node(
+            OpKind::Constant,
+            SmallVec::new(),
+            meta.clone(),
+            Some(&[1.0, 2.0]),
+        );
+        let b = g.intern_node(
+            OpKind::Constant,
+            SmallVec::new(),
+            meta.clone(),
+            Some(&[1.0, 2.0]),
+        );
+        assert_ne!(a, b);
+        assert_eq!(g.len(), 2);
+    }
+
+    #[test]
+    fn test_cse_dedups_ops() {
         let mut g = Graph::new();
         let meta = TensorMeta {
             shape: Shape::new(vec![2]),
@@ -489,10 +551,8 @@ mod tests {
             OpKind::Constant,
             SmallVec::new(),
             meta.clone(),
-            Some(&[1.0, 2.0]),
+            Some(&[3.0, 4.0]),
         );
-        assert_eq!(a, b);
-        assert_eq!(g.len(), 1);
 
         let add1 = g.intern_node(
             OpKind::Add,
@@ -507,6 +567,6 @@ mod tests {
             None,
         );
         assert_eq!(add1, add2);
-        assert_eq!(g.len(), 2);
+        assert_eq!(g.len(), 3); // 2 constants + 1 deduplicated add
     }
 }

--- a/crates/mlx-ffi-backend/src/lib.rs
+++ b/crates/mlx-ffi-backend/src/lib.rs
@@ -303,11 +303,9 @@ impl Backend for MlxFfiBackend {
             | OpKind::SoftmaxVjp { .. }
             | OpKind::SiluVjp
             | OpKind::GeluVjp
-            | OpKind::Sqrt => {
-                Err(MlxError::InvalidArgument(format!(
-                    "{op:?} not supported by FFI backend",
-                )))
-            }
+            | OpKind::Sqrt => Err(MlxError::InvalidArgument(format!(
+                "{op:?} not supported by FFI backend",
+            ))),
             OpKind::Constant | OpKind::Parameter => Err(MlxError::InvalidArgument(
                 "Constant/Parameter should be pre-materialized by Stream".into(),
             )),

--- a/crates/mlx-optim/src/lib.rs
+++ b/crates/mlx-optim/src/lib.rs
@@ -191,8 +191,7 @@ impl Optimizer for AdamW {
 
 /// Create a scalar tensor broadcast to the same shape/dtype/device as `like`.
 fn scalar_like(val: f32, like: &Tensor) -> Result<Tensor> {
-    Tensor::from_f32(&[val], &mlx_core::Shape::scalar(), like.device())?
-        .broadcast_to(like.shape())
+    Tensor::from_f32(&[val], &mlx_core::Shape::scalar(), like.device())?.broadcast_to(like.shape())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Disable CSE (Common Subexpression Elimination) for `OpKind::Constant` nodes — two tensors with identical data may flow through different parts of the graph and receive independent gradients during backpropagation
- Fixes `test_grad_softmax_weighted` which was failing across all CI runs on develop
- Updates CSE tests to reflect the new behavior

## Root Cause
When two tensors (`x` and `w`) had identical data (e.g., `[1.0, 2.0, 3.0]`), CSE mapped them to the same `NodeId`. During backward pass, gradients for both tensors were accumulated into the same node, producing incorrect results.

## Test plan
- [x] `test_grad_softmax_weighted` now passes (was the only failing test across all CI)
- [x] All 198 workspace tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)