### PR TITLE
Add issue templates and Metal parity matrix

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,63 @@
+name: Epic
+description: Multi-week architectural milestone spanning multiple stories
+title: "Epic: <name>"
+labels: ["epic"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why this epic matters + what capability it unlocks
+      placeholder: |
+        Example: Enable loading pretrained LLM weights via safetensors + mmap.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is included / excluded in this epic
+      placeholder: |
+        Included:
+        - Reader + mmap support
+        Excluded:
+        - Quantized GGUF
+    validations:
+      required: true
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Deliverables
+      description: Concrete outputs expected when epic is complete
+      placeholder: |
+        - mlx-io crate implements safetensors read/write
+        - Golden tests pass
+        - CI wired for conformance
+    validations:
+      required: true
+
+  - type: textarea
+    id: stories
+    attributes:
+      label: Stories (child issues)
+      description: Link all story-level issues here
+      placeholder: |
+        - [ ] #123 Story: Safetensors reader
+        - [ ] #124 Story: mmap loader
+        - [ ] #125 Story: writer + roundtrip tests
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Epic Acceptance Criteria
+      description: Conditions required to close the epic
+      placeholder: |
+        - All child stories closed
+        - CI green
+        - Docs updated
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/metal_kernel.yml
+++ b/.github/ISSUE_TEMPLATE/metal_kernel.yml
@@ -1,0 +1,49 @@
+name: Metal Kernel Story
+description: Add a new Metal op with parity + golden coverage
+title: "Metal: <op>"
+labels: ["metal", "kernel"]
+body:
+  - type: textarea
+    id: op
+    attributes:
+      label: Operation
+      placeholder: |
+        Op: Softmax(axis=-1)
+        Input: [rows, cols]
+        Output: same shape
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation Tasks
+      placeholder: |
+        - [ ] Add kernel file in crates/mlx-metal/src/kernels/
+        - [ ] Add pipeline cache entry
+        - [ ] Add dispatch wrapper in Rust
+        - [ ] Add CPU fallback if unsupported
+    validations:
+      required: true
+
+  - type: textarea
+    id: testing
+    attributes:
+      label: Required Tests
+      placeholder: |
+        - [ ] Golden test vs Python MLX
+        - [ ] Parity test vs CPU backend
+        - [ ] Shape/property tests (proptest)
+    validations:
+      required: true
+
+  - type: textarea
+    id: perf
+    attributes:
+      label: Performance Baseline
+      placeholder: |
+        Record timing for:
+        - rows=128 cols=4096
+        - rows=512 cols=8192
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/parity_gate.yml
+++ b/.github/ISSUE_TEMPLATE/parity_gate.yml
@@ -1,0 +1,38 @@
+name: Backend Parity Gate
+description: Track requirements before enabling Metal by default
+title: "Gate: Metal backend default enablement"
+labels: ["parity", "gate"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      placeholder: |
+        Metal backend cannot be default until parity suite is green for all required ops.
+    validations:
+      required: true
+
+  - type: textarea
+    id: required_ops
+    attributes:
+      label: Required Ops Matrix
+      placeholder: |
+        - [ ] Add/Sub/Mul/Div/Neg
+        - [ ] MatMul
+        - [ ] Softmax + Mask
+        - [ ] RMSNorm / LayerNorm
+        - [ ] RoPE
+        - [ ] Attention block golden
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      placeholder: |
+        - cargo test -p mlx-parity passes on Apple Silicon
+        - CI runs parity suite nightly
+        - Feature flag flips default backend
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -1,0 +1,66 @@
+name: Story
+description: A single feature implementation with tests + acceptance criteria
+title: "Story: <feature>"
+labels: ["story"]
+body:
+  - type: textarea
+    id: user_story
+    attributes:
+      label: User Story
+      description: Who wants this and why?
+      placeholder: |
+        As an LLM engineer,
+        I want RMSNorm on Metal,
+        so inference runs efficiently on Apple Silicon.
+    validations:
+      required: true
+
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: Exact behavior + constraints
+      placeholder: |
+        - FP16 input, FP32 accumulation
+        - axis=-1 only
+        - Supports hidden dims up to 8192
+    validations:
+      required: true
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: Implementation checklist
+      placeholder: |
+        - [ ] Add kernel: rmsnorm_fp16.metal
+        - [ ] Add Rust dispatch: norm.rs
+        - [ ] Add golden tests
+        - [ ] Add perf baseline bench
+    validations:
+      required: true
+
+  - type: textarea
+    id: tests
+    attributes:
+      label: Test Checklist
+      description: What tests must exist before merge?
+      placeholder: |
+        - [ ] Unit tests (shape validation)
+        - [ ] Golden tests vs Python MLX
+        - [ ] Parity test (Metal vs CPU)
+        - [ ] Stress test (optional)
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Conditions required to close the story
+      placeholder: |
+        - cargo test -p mlx-metal passes
+        - Golden output matches tolerance
+        - Parity suite includes this op
+    validations:
+      required: true

--- a/docs/PARITY_MATRIX.md
+++ b/docs/PARITY_MATRIX.md
@@ -1,0 +1,74 @@
+# Backend Parity Suite Matrix
+
+Metal backend may not become default until all REQUIRED ops are green.
+
+Legend:
+- CPU = Rust reference backend
+- FFI = MLX upstream backend (ground truth)
+- Metal = Native Apple GPU backend
+- Tests:
+  - U = Unit tests
+  - P = Property tests (proptest)
+  - G = Golden vs Python MLX
+  - R = Parity vs CPU/FFI
+  - B = Bench baseline
+
+---
+
+## Required Ops Before Metal Default
+
+| Op Category     | Operation        | CPU | FFI | Metal | Required Tests        | Default Gate |
+|-----------------|------------------|-----|-----|-------|-----------------------|--------------|
+| Elementwise     | Add              | ✅  | ✅  | ✅    | U + R                 | ✅ Required  |
+| Elementwise     | Sub              | ✅  | ✅  | ✅    | U + R                 | ✅ Required  |
+| Elementwise     | Mul              | ✅  | ✅  | ✅    | U + R                 | ✅ Required  |
+| Elementwise     | Div              | ✅  | ✅  | ✅    | U + R                 | ✅ Required  |
+| Elementwise     | Neg              | ✅  | ✅  | ✅    | U + R                 | ✅ Required  |
+| GEMM            | MatMul           | ✅  | ✅  | ✅    | U + G + R + B         | ✅ Required  |
+| Activations     | Silu             | ✅  | ✅  | ✅    | U + G + R             | ✅ Required  |
+| Activations     | Gelu             | ✅  | ✅  | ✅    | U + G + R             | ✅ Required  |
+| Softmax         | Softmax(axis=-1) | ✅  | ✅  | ✅    | U + G + R             | ✅ Required  |
+| Masking         | Causal Mask      | ✅  | ✅  | ✅    | U + G                 | ✅ Required  |
+| Norm            | RMSNorm          | ✅  | ✅  | ✅    | U + G + R + B         | ✅ Required  |
+| Norm            | LayerNorm        | ✅  | ✅  | ✅    | U + G + R + B         | ✅ Required  |
+| Positional      | RoPE             | ✅  | ✅  | ✅    | U + G + R             | ✅ Required  |
+| Reduction       | Sum              | ✅  | ✅  | ⬜    | U + P + R             | ⚠ Optional   |
+| Reduction       | Mean             | ✅  | ✅  | ⬜    | U + P + R             | ⚠ Optional   |
+| Reduction       | Max              | ✅  | ✅  | ⬜    | U + P + R             | ⚠ Optional   |
+| Shape Ops       | Reshape          | ✅  | ✅  | ⬜    | U + P                 | ⚠ Optional   |
+| Shape Ops       | Transpose        | ✅  | ✅  | ✅    | U + P                 | ⚠ Optional   |
+| Shape Ops       | Broadcast        | ✅  | ✅  | ⬜    | U + P                 | ⚠ Optional   |
+| Attention       | SDPA Block       | ✅  | ✅  | ✅    | Golden Functional Test| ✅ Required  |
+
+---
+
+## Metal Default Flip Criteria
+
+Metal backend may become default when:
+
+- All REQUIRED ops above are implemented in Metal
+- Parity suite passes on Apple Silicon runner:
+
+```bash
+cargo test -p mlx-parity --features default-backend-metal
+```
+
+- Golden attention block test passes:
+
+```bash
+cargo test -p mlx-metal attention_block_goldens
+```
+
+- Feature flag is flipped in release builds:
+
+```toml
+[features]
+default = ["default-backend-metal"]
+```
+
+Until then, Metal remains opt-in:
+
+```bash
+cargo test --features metal
+MLX_RS_BACKEND=metal
+```


### PR DESCRIPTION
## Summary
- Add 4 GitHub issue templates (`.github/ISSUE_TEMPLATE/`): Epic, Story, Metal Kernel, Backend Parity Gate
- Add `docs/PARITY_MATRIX.md` — single gate document tracking which ops must be green before Metal becomes the default backend
- Parity matrix reflects actual codebase state: all 13 required ops have Metal implementations; optional ops (reductions, reshape, broadcast) still pending

## Test plan
- [x] YAML templates are valid GitHub issue form syntax
- [x] Parity matrix Metal status verified against `crates/mlx-metal/src/backend.rs` dispatch code
- [ ] Verify templates appear in GitHub "New Issue" picker after merge

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)