### PR TITLE
Fix mlx-bench clippy warnings

### DIFF
--- a/crates/mlx-bench/API.md
+++ b/crates/mlx-bench/API.md
@@ -114,9 +114,6 @@ impl TaskSet {
     /// Get tasks matching glob pattern
     pub fn by_glob(&self, glob_pattern: &str) -> Vec<&EvalTask>;
 
-    /// Base directory path
-    pub fn base_dir(&self) -> &Path;
-
     /// Validate all tasks
     pub fn validate(&self) -> Result<()>;
 }
@@ -325,9 +322,6 @@ pub trait LlmBackend: Send + Sync {
         task: &EvalTask,
         opts: &BackendOpts,
     ) -> Result<String>;
-
-    /// Backend name for logging
-    fn name(&self) -> &str;
 }
 ```
 
@@ -356,10 +350,6 @@ impl LlmBackend for CustomBackend {
         // Call your LLM API
         // Return patch text
         Ok("--- a/...".to_string())
-    }
-
-    fn name(&self) -> &str {
-        "custom"
     }
 }
 ```
@@ -409,7 +399,6 @@ impl LlmBackend for LocalMlxBackend { ... }
 use mlx_bench::backend::LocalMlxBackend;
 
 let backend = LocalMlxBackend::new("deepseek-coder-1.3b");
-println!("Backend: {}", backend.name());  // "local"
 // Will return error indicating mlx-rs bindings are required
 ```
 
@@ -440,11 +429,10 @@ The `AnthropicApiBackend` creates a new `tokio::runtime::Runtime` for each `gene
 
 **Example:**
 ```rust
-use mlx_bench::backend::AnthropicApiBackend;
+use mlx_bench::backend::{AnthropicApiBackend, LlmBackend};
 
 // Requires ANTHROPIC_API_KEY environment variable
 let backend = AnthropicApiBackend::new()?;
-println!("Backend: {}", backend.name());  // "anthropic"
 
 // The backend will call the Anthropic API and return a patch
 let patch = backend.generate_patch(&task, &opts)?;

--- a/crates/mlx-bench/ARCHITECTURE.md
+++ b/crates/mlx-bench/ARCHITECTURE.md
@@ -17,7 +17,6 @@ The `LlmBackend` trait enables pluggable LLM providers:
 ```rust
 pub trait LlmBackend: Send + Sync {
     fn generate_patch(&self, task: &EvalTask, opts: &BackendOpts) -> Result<String>;
-    fn name(&self) -> &str;
 }
 ```
 
@@ -186,7 +185,6 @@ impl TaskRunner {
 ```rust
 pub trait LlmBackend: Send + Sync {
     fn generate_patch(&self, task: &EvalTask, opts: &BackendOpts) -> Result<String>;
-    fn name(&self) -> &str;
 }
 ```
 
@@ -339,7 +337,6 @@ TaskSet::load_from_dir()
     ↓
 TaskSet {
     tasks: Vec<EvalTask>,
-    base_dir: PathBuf,
 }
     ↓
 [In-memory task collection]
@@ -403,10 +400,6 @@ pub struct MyBackend {
 impl LlmBackend for MyBackend {
     fn generate_patch(&self, task: &EvalTask, opts: &BackendOpts) -> Result<String> {
         // Your implementation
-    }
-
-    fn name(&self) -> &str {
-        "my-backend"
     }
 }
 ```

--- a/crates/mlx-bench/src/backend.rs
+++ b/crates/mlx-bench/src/backend.rs
@@ -13,7 +13,6 @@ pub struct BackendOpts {
 
 pub trait LlmBackend: Send + Sync {
     fn generate_patch(&self, task: &EvalTask, opts: &BackendOpts) -> Result<String>;
-    fn name(&self) -> &str;
 }
 
 /// Anthropic API backend using official Rust SDK
@@ -23,10 +22,9 @@ pub struct AnthropicApiBackend {
 
 impl AnthropicApiBackend {
     pub fn new() -> Result<Self> {
-        let api_key = env::var("ANTHROPIC_API_KEY")
-            .map_err(|_| BenchError::Backend(
-                "ANTHROPIC_API_KEY environment variable not set".to_string()
-            ))?;
+        let api_key = env::var("ANTHROPIC_API_KEY").map_err(|_| {
+            BenchError::Backend("ANTHROPIC_API_KEY environment variable not set".to_string())
+        })?;
 
         Ok(AnthropicApiBackend { api_key })
     }
@@ -38,13 +36,7 @@ impl LlmBackend for AnthropicApiBackend {
         let rt = tokio::runtime::Runtime::new()
             .map_err(|e| BenchError::Backend(format!("Failed to create runtime: {}", e)))?;
 
-        rt.block_on(async {
-            generate_patch_async(task, opts, &self.api_key).await
-        })
-    }
-
-    fn name(&self) -> &str {
-        "anthropic"
+        rt.block_on(async { generate_patch_async(task, opts, &self.api_key).await })
     }
 }
 
@@ -167,10 +159,6 @@ impl LlmBackend for LocalMlxBackend {
                 .to_string(),
         ))
     }
-
-    fn name(&self) -> &str {
-        "local"
-    }
 }
 
 /// Debug backend that reads patch from environment or file
@@ -185,13 +173,10 @@ impl LlmBackend for StdinDebugBackend {
             Ok(patch_content)
         } else {
             Err(BenchError::Backend(
-                "Set either BENCH_PATCH_FILE or BENCH_PATCH_CONTENT environment variable".to_string(),
+                "Set either BENCH_PATCH_FILE or BENCH_PATCH_CONTENT environment variable"
+                    .to_string(),
             ))
         }
-    }
-
-    fn name(&self) -> &str {
-        "debug"
     }
 }
 

--- a/crates/mlx-bench/src/error.rs
+++ b/crates/mlx-bench/src/error.rs
@@ -18,6 +18,7 @@ pub enum BenchError {
     Backend(String),
 
     #[error("LLM generation failed: {0}")]
+    #[allow(dead_code)]
     LlmGeneration(String),
 
     #[error("Patch validation failed: {0}")]
@@ -33,6 +34,7 @@ pub enum BenchError {
     Git(String),
 
     #[error("Timeout exceeded")]
+    #[allow(dead_code)]
     Timeout,
 
     #[error("Invalid configuration: {0}")]
@@ -47,7 +49,10 @@ mod tests {
 
     #[test]
     fn test_error_display_io() {
-        let err = BenchError::Io(std::io::Error::new(std::io::ErrorKind::NotFound, "file not found"));
+        let err = BenchError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "file not found",
+        ));
         assert!(err.to_string().contains("IO error"));
     }
 

--- a/crates/mlx-bench/src/main.rs
+++ b/crates/mlx-bench/src/main.rs
@@ -4,7 +4,7 @@ mod report;
 mod runner;
 mod task;
 
-use backend::{AnthropicApiBackend, BackendOpts, LocalMlxBackend, StdinDebugBackend, LlmBackend};
+use backend::{AnthropicApiBackend, BackendOpts, LocalMlxBackend, StdinDebugBackend};
 use clap::{Parser, Subcommand};
 use error::Result;
 use report::{ReportFormat, Reporter};
@@ -107,9 +107,10 @@ fn run(args: Args) -> Result<()> {
 
     match args.cmd {
         Cmd::ListTasks { json } => cmd_list_tasks(&tasks, json),
-        Cmd::ShowTask { task_id, show_context } => {
-            cmd_show_task(&tasks, &task_id, show_context, &args.workspace)
-        }
+        Cmd::ShowTask {
+            task_id,
+            show_context,
+        } => cmd_show_task(&tasks, &task_id, show_context, &args.workspace),
         Cmd::ValidateTasks => cmd_validate_tasks(&tasks),
         Cmd::SelfTest { filter } => cmd_self_test(&tasks, filter.as_deref(), &args.workspace),
         Cmd::Run {
@@ -127,9 +128,11 @@ fn run(args: Args) -> Result<()> {
             dry_run,
             &args.workspace,
         ),
-        Cmd::Report { format, latest, file } => {
-            cmd_report(&format, latest, file.as_deref())
-        }
+        Cmd::Report {
+            format,
+            latest,
+            file,
+        } => cmd_report(&format, latest, file.as_deref()),
     }
 }
 
@@ -317,7 +320,7 @@ fn cmd_run(
                 return Err(error::BenchError::InvalidConfig(format!(
                     "Unknown backend: {}",
                     backend_name
-                )))
+                )));
             }
         };
 
@@ -353,7 +356,7 @@ fn cmd_report(format_str: &str, latest: bool, file: Option<&std::path::Path>) ->
             return Err(error::BenchError::InvalidConfig(format!(
                 "Unknown format: {}",
                 format_str
-            )))
+            )));
         }
     };
 
@@ -370,21 +373,18 @@ fn cmd_report(format_str: &str, latest: bool, file: Option<&std::path::Path>) ->
         for entry in entries {
             let entry = entry?;
             let path = entry.path();
-            if path.extension().and_then(|s| s.to_str()) == Some("json") {
-                if let Ok(metadata) = entry.metadata() {
-                    if let Ok(modified) = metadata.modified() {
-                        if modified > latest_time {
-                            latest_time = modified;
-                            latest_file = Some(path);
-                        }
-                    }
-                }
+            if path.extension().and_then(|s| s.to_str()) == Some("json")
+                && let Ok(metadata) = entry.metadata()
+                && let Ok(modified) = metadata.modified()
+                && modified > latest_time
+            {
+                latest_time = modified;
+                latest_file = Some(path);
             }
         }
 
-        latest_file.ok_or_else(|| {
-            error::BenchError::InvalidConfig("No result files found".to_string())
-        })?
+        latest_file
+            .ok_or_else(|| error::BenchError::InvalidConfig("No result files found".to_string()))?
     } else {
         return Err(error::BenchError::InvalidConfig(
             "Must specify --file or --latest".to_string(),

--- a/crates/mlx-bench/src/report.rs
+++ b/crates/mlx-bench/src/report.rs
@@ -40,7 +40,10 @@ impl Reporter {
         output.push_str(&format!("Pass@1: {:.2}%\n", result.pass_at_1() * 100.0));
         output.push_str(&format!("Pass@3: {:.2}%\n", result.pass_at_k(3) * 100.0));
         output.push_str(&format!("Pass@5: {:.2}%\n", result.pass_at_k(5) * 100.0));
-        output.push_str(&format!("Compilation Rate: {:.2}%\n\n", result.compilation_rate() * 100.0));
+        output.push_str(&format!(
+            "Compilation Rate: {:.2}%\n\n",
+            result.compilation_rate() * 100.0
+        ));
 
         // Task details
         output.push_str("=== TASK RESULTS ===\n");
@@ -96,9 +99,18 @@ impl Reporter {
         output.push_str("## Summary Metrics\n\n");
         output.push_str("| Metric | Value |\n");
         output.push_str("|--------|-------|\n");
-        output.push_str(&format!("| Pass@1 | {:.2}% |\n", result.pass_at_1() * 100.0));
-        output.push_str(&format!("| Pass@3 | {:.2}% |\n", result.pass_at_k(3) * 100.0));
-        output.push_str(&format!("| Pass@5 | {:.2}% |\n", result.pass_at_k(5) * 100.0));
+        output.push_str(&format!(
+            "| Pass@1 | {:.2}% |\n",
+            result.pass_at_1() * 100.0
+        ));
+        output.push_str(&format!(
+            "| Pass@3 | {:.2}% |\n",
+            result.pass_at_k(3) * 100.0
+        ));
+        output.push_str(&format!(
+            "| Pass@5 | {:.2}% |\n",
+            result.pass_at_k(5) * 100.0
+        ));
         output.push_str(&format!(
             "| Compilation Rate | {:.2}% |\n",
             result.compilation_rate() * 100.0

--- a/crates/mlx-bench/src/report.rs
+++ b/crates/mlx-bench/src/report.rs
@@ -103,7 +103,7 @@ impl Reporter {
             "| Compilation Rate | {:.2}% |\n",
             result.compilation_rate() * 100.0
         ));
-        output.push_str("\n");
+        output.push('\n');
 
         // Aggregate by task
         let mut task_map: HashMap<String, Vec<_>> = HashMap::new();

--- a/crates/mlx-bench/src/runner.rs
+++ b/crates/mlx-bench/src/runner.rs
@@ -226,7 +226,7 @@ impl TaskRunner {
     fn run_build(&self, task: &EvalTask) -> Result<bool> {
         for crate_name in &task.test_crates {
             let output = Command::new("cargo")
-                .args(&["build", "-p", crate_name, "--quiet"])
+                .args(["build", "-p", crate_name, "--quiet"])
                 .current_dir(&self.config.workspace_root)
                 .output()
                 .map_err(|e| BenchError::BuildFailed(format!("Build command failed: {}", e)))?;
@@ -243,7 +243,7 @@ impl TaskRunner {
         for crate_name in &task.test_crates {
             let mut cmd = Command::new("cargo");
             cmd.arg("test")
-                .args(&["-p", crate_name])
+                .args(["-p", crate_name])
                 .current_dir(&self.config.workspace_root);
 
             for filter in &task.test_filters {
@@ -264,7 +264,7 @@ impl TaskRunner {
 
     fn revert_changes(&self) -> Result<()> {
         let output = Command::new("git")
-            .args(&["checkout", "--", "."])
+            .args(["checkout", "--", "."])
             .current_dir(&self.config.workspace_root)
             .output()
             .map_err(|e| BenchError::Git(format!("Failed to spawn git checkout: {}", e)))?;

--- a/crates/mlx-bench/src/runner.rs
+++ b/crates/mlx-bench/src/runner.rs
@@ -32,6 +32,7 @@ pub struct EvalResult {
 pub struct RunConfig {
     pub workspace_root: PathBuf,
     pub max_attempts: usize,
+    #[allow(dead_code)]
     pub timeout_secs: u64,
 }
 
@@ -156,7 +157,8 @@ impl TaskRunner {
         // Stricter check: must start with "--- " and contain "\n+++ "
         if !patch.starts_with("--- ") || !patch.contains("\n+++ ") {
             return Err(BenchError::PatchValidation(
-                "Patch missing proper --- and +++ headers (unified diff format required)".to_string(),
+                "Patch missing proper --- and +++ headers (unified diff format required)"
+                    .to_string(),
             ));
         }
 
@@ -217,7 +219,10 @@ impl TaskRunner {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(BenchError::Git(format!("Patch application failed: {}", stderr)));
+            return Err(BenchError::Git(format!(
+                "Patch application failed: {}",
+                stderr
+            )));
         }
 
         Ok(())
@@ -356,7 +361,12 @@ mod tests {
     use super::*;
 
     // Helper to create a test outcome
-    fn test_outcome(task_id: &str, attempt: usize, tests_passed: bool, build_success: bool) -> TaskOutcome {
+    fn test_outcome(
+        task_id: &str,
+        attempt: usize,
+        tests_passed: bool,
+        build_success: bool,
+    ) -> TaskOutcome {
         TaskOutcome {
             task_id: task_id.to_string(),
             attempt,
@@ -480,8 +490,8 @@ mod tests {
     #[test]
     fn test_compilation_rate_partial() {
         let mut result = EvalResult::new();
-        result.outcomes.push(test_outcome("task1", 1, false, true));  // compiled, no test
-        result.outcomes.push(test_outcome("task2", 1, true, true));   // compiled, passed
+        result.outcomes.push(test_outcome("task1", 1, false, true)); // compiled, no test
+        result.outcomes.push(test_outcome("task2", 1, true, true)); // compiled, passed
         result.outcomes.push(test_outcome("task3", 1, false, false)); // didn't compile
         // 2 out of 3 compiled
         assert!((result.compilation_rate() - (2.0 / 3.0)).abs() < 0.01);

--- a/crates/mlx-bench/src/task.rs
+++ b/crates/mlx-bench/src/task.rs
@@ -1,7 +1,7 @@
 use crate::error::{BenchError, Result};
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvalTask {
@@ -26,7 +26,6 @@ pub struct ContextFile {
 
 pub struct TaskSet {
     tasks: Vec<EvalTask>,
-    base_dir: PathBuf,
 }
 
 impl TaskSet {
@@ -49,26 +48,20 @@ impl TaskSet {
             .map_err(|e| BenchError::InvalidConfig(format!("Glob error: {}", e)))?;
 
         for entry in entries {
-            let path = entry.map_err(|e| {
-                BenchError::InvalidConfig(format!("Path iteration error: {}", e))
-            })?;
+            let path = entry
+                .map_err(|e| BenchError::InvalidConfig(format!("Path iteration error: {}", e)))?;
 
             let content = fs::read_to_string(&path).map_err(BenchError::Io)?;
 
             let task: EvalTask = serde_json::from_str(&content)
-                .map_err(|e| {
-                    BenchError::InvalidTask(format!("{}: {}", path.display(), e))
-                })?;
+                .map_err(|e| BenchError::InvalidTask(format!("{}: {}", path.display(), e)))?;
 
             tasks.push(task);
         }
 
         tasks.sort_by(|a, b| a.id.cmp(&b.id));
 
-        Ok(TaskSet {
-            tasks,
-            base_dir: base_dir.to_path_buf(),
-        })
+        Ok(TaskSet { tasks })
     }
 
     pub fn all(&self) -> &[EvalTask] {
@@ -82,22 +75,18 @@ impl TaskSet {
     pub fn by_glob(&self, glob_pattern: &str) -> Vec<&EvalTask> {
         self.tasks
             .iter()
-            .filter(|t| glob::Pattern::new(glob_pattern)
-                .map(|p| p.matches(&t.id))
-                .unwrap_or(false))
+            .filter(|t| {
+                glob::Pattern::new(glob_pattern)
+                    .map(|p| p.matches(&t.id))
+                    .unwrap_or(false)
+            })
             .collect()
-    }
-
-    pub fn base_dir(&self) -> &Path {
-        &self.base_dir
     }
 
     pub fn validate(&self) -> Result<()> {
         for task in &self.tasks {
             if task.id.is_empty() {
-                return Err(BenchError::InvalidTask(
-                    "Task missing id".to_string(),
-                ));
+                return Err(BenchError::InvalidTask("Task missing id".to_string()));
             }
             if task.title.is_empty() {
                 return Err(BenchError::InvalidTask(format!(

--- a/crates/mlx-bench/src/task.rs
+++ b/crates/mlx-bench/src/task.rs
@@ -53,8 +53,7 @@ impl TaskSet {
                 BenchError::InvalidConfig(format!("Path iteration error: {}", e))
             })?;
 
-            let content = fs::read_to_string(&path)
-                .map_err(|e| BenchError::Io(e))?;
+            let content = fs::read_to_string(&path).map_err(BenchError::Io)?;
 
             let task: EvalTask = serde_json::from_str(&content)
                 .map_err(|e| {
@@ -147,8 +146,7 @@ impl ContextFile {
             )));
         }
 
-        let content = fs::read_to_string(&path)
-            .map_err(|e| BenchError::Io(e))?;
+        let content = fs::read_to_string(&path).map_err(BenchError::Io)?;
 
         match self.lines {
             None => Ok(content),


### PR DESCRIPTION
## Summary
- Replace single-character `push_str` with `push` in markdown report output
- Remove needless borrows from `Command::args` calls and redundant `map_err` closures
- Remove unused `mlx-bench` API surface and update docs to match the new API shape
- Apply `cargo fmt` to the touched benchmark files

## Test plan
- `cargo fmt --check`
- `cargo clippy -p mlx-bench --all-targets -- -D warnings`

Related: unblocks the clippy failures observed in #136 CI.