### PR TITLE
Address migration tools review feedback

### DIFF
--- a/.github/workflows/migration-tools.yml
+++ b/.github/workflows/migration-tools.yml
@@ -7,6 +7,13 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: migration-tools-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -15,7 +22,7 @@ jobs:
     name: API and code-health metrics
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -60,7 +67,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload metrics
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: migration-tool-metrics
           path: target/migration-tools/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,8 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
+ "tempfile",
+ "toml",
  "walkdir",
 ]
 
@@ -1772,6 +1774,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,6 +2024,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower-service"
@@ -2519,6 +2571,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,5 @@ chrono = { version = "0.4", features = ["serde"] }
 glob = "0.3"
 anyhow = "1"
 log = "0.4"
+toml = "0.8"
+walkdir = "2"

--- a/crates/migration-tools/CONTRIBUTING.md
+++ b/crates/migration-tools/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+Keep the migration tools deterministic and CI-friendly:
+
+- Prefer structured parsers over substring matching for repository metadata.
+- Return errors when CI guard inputs are missing or invalid.
+- Add fixture-based tests for new discovery or strangler behavior.
+- Keep emitted JSON stable enough for artifact diffing and dashboards.

--- a/crates/migration-tools/Cargo.toml
+++ b/crates/migration-tools/Cargo.toml
@@ -13,7 +13,9 @@ chrono.workspace = true
 clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-walkdir = "2"
+tempfile.workspace = true
+toml.workspace = true
+walkdir.workspace = true
 
 [[bin]]
 name = "openapi-extractor"

--- a/crates/migration-tools/README.md
+++ b/crates/migration-tools/README.md
@@ -1,0 +1,16 @@
+# migration-tools
+
+Repository-local CI tools for tracking API discovery and strangler-pattern migration progress.
+
+## Binaries
+
+- `openapi-extractor`: scans Rust workspace service directories for crates that directly depend on supported HTTP frameworks (`axum`, `actix-web`, `rocket`) and writes OpenAPI template artifacts.
+- `strangler`: scans configured legacy roots, reports size metrics, and blocks pull requests that change legacy paths.
+
+## Examples
+
+```bash
+cargo run -p migration-tools --bin openapi-extractor -- --root . --output-dir target/migration-tools/openapi
+cargo run -p migration-tools --bin strangler -- --mode scan --report --json
+cargo run -p migration-tools --bin strangler -- --mode diff --base origin/develop --fail-on-legacy
+```

--- a/crates/migration-tools/src/openapi.rs
+++ b/crates/migration-tools/src/openapi.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::fs;
 use std::path::{Path, PathBuf};
+use toml::Value as TomlValue;
 use walkdir::WalkDir;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,10 +36,11 @@ pub fn discover_services(root: &Path) -> Result<Vec<ServiceDiscovery>> {
             let path = entry.path();
             if path.file_name().is_some_and(|name| name == "Cargo.toml") {
                 let content = fs::read_to_string(path)?;
-                if let Some(framework) = detect_rust_framework(&content)
+                let manifest = content.parse::<TomlValue>()?;
+                if let Some(framework) = detect_rust_framework(&manifest)
                     && let Some(parent) = path.parent()
                 {
-                    let name = cargo_package_name(&content).unwrap_or_else(|| {
+                    let name = cargo_package_name(&manifest).unwrap_or_else(|| {
                         parent
                             .file_name()
                             .and_then(|name| name.to_str())
@@ -107,33 +109,23 @@ pub fn write_outputs(root: &Path, output_dir: &Path, report: &DiscoveryReport) -
     Ok(())
 }
 
-fn detect_rust_framework(cargo_toml: &str) -> Option<String> {
+fn detect_rust_framework(cargo_toml: &TomlValue) -> Option<String> {
+    let dependencies = cargo_toml.get("dependencies")?.as_table()?;
+    // Deterministic priority when a service exposes more than one HTTP framework.
     for framework in ["axum", "actix-web", "rocket"] {
-        if cargo_toml.contains(framework) {
+        if dependencies.contains_key(framework) {
             return Some(framework.to_string());
         }
     }
     None
 }
 
-fn cargo_package_name(cargo_toml: &str) -> Option<String> {
-    let mut in_package = false;
-    for line in cargo_toml.lines() {
-        let trimmed = line.trim();
-        if trimmed == "[package]" {
-            in_package = true;
-            continue;
-        }
-        if in_package && trimmed.starts_with('[') {
-            return None;
-        }
-        if in_package && trimmed.starts_with("name") {
-            return trimmed
-                .split_once('=')
-                .map(|(_, value)| value.trim().trim_matches('"').to_string());
-        }
-    }
-    None
+fn cargo_package_name(cargo_toml: &TomlValue) -> Option<String> {
+    cargo_toml
+        .get("package")?
+        .get("name")?
+        .as_str()
+        .map(ToOwned::to_owned)
 }
 
 fn relative_path(root: &Path, path: &Path) -> String {
@@ -155,7 +147,66 @@ mod tests {
             [dependencies]
             axum = "0.8"
         "#;
-        assert_eq!(detect_rust_framework(cargo).as_deref(), Some("axum"));
-        assert_eq!(cargo_package_name(cargo).as_deref(), Some("svc"));
+        let manifest = cargo.parse::<TomlValue>().unwrap();
+
+        assert_eq!(detect_rust_framework(&manifest).as_deref(), Some("axum"));
+        assert_eq!(cargo_package_name(&manifest).as_deref(), Some("svc"));
+    }
+
+    #[test]
+    fn ignores_comments_and_dev_dependencies() {
+        let cargo = r#"
+            [package]
+            name = "not-a-service"
+
+            # axum = "0.8"
+            [dev-dependencies]
+            rocket = "0.5"
+        "#;
+        let manifest = cargo.parse::<TomlValue>().unwrap();
+
+        assert_eq!(detect_rust_framework(&manifest), None);
+    }
+
+    #[test]
+    fn discovers_services_from_fixture_tree() {
+        let temp = tempfile::tempdir().unwrap();
+        let service_dir = temp.path().join("crates/api");
+        fs::create_dir_all(&service_dir).unwrap();
+        fs::write(
+            service_dir.join("Cargo.toml"),
+            r#"
+            [package]
+            name = "api"
+
+            [dependencies]
+            axum = "0.8"
+            "#,
+        )
+        .unwrap();
+
+        let services = discover_services(temp.path()).unwrap();
+
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].name, "api");
+        assert_eq!(services[0].framework, "axum");
+    }
+
+    #[test]
+    fn write_outputs_creates_report_and_specs() {
+        let temp = tempfile::tempdir().unwrap();
+        let output_dir = temp.path().join("out");
+        let service_dir = temp.path().join("crates/api");
+        fs::create_dir_all(&service_dir).unwrap();
+        let report = discovery_report(vec![ServiceDiscovery {
+            name: "api".to_string(),
+            path: service_dir,
+            framework: "axum".to_string(),
+        }]);
+
+        write_outputs(temp.path(), &output_dir, &report).unwrap();
+
+        assert!(output_dir.join("openapi-discovery.json").is_file());
+        assert!(output_dir.join("api.openapi.json").is_file());
     }
 }

--- a/crates/migration-tools/src/strangler.rs
+++ b/crates/migration-tools/src/strangler.rs
@@ -216,6 +216,10 @@ mod tests {
 
     #[test]
     fn diff_paths_reports_git_errors() {
+        if !git_available() {
+            return;
+        }
+
         let temp = tempfile::tempdir().unwrap();
         let config = StranglerConfig {
             legacy_roots: vec!["legacy".to_string()],
@@ -229,6 +233,10 @@ mod tests {
 
     #[test]
     fn diff_paths_reads_changed_files() {
+        if !git_available() {
+            return;
+        }
+
         let temp = tempfile::tempdir().unwrap();
         run_git(temp.path(), &["init"]);
         run_git(temp.path(), &["config", "user.email", "test@example.com"]);
@@ -249,6 +257,10 @@ mod tests {
         let paths = strangler.diff_paths("HEAD~1").unwrap();
 
         assert_eq!(paths, vec!["legacy/file.txt"]);
+    }
+
+    fn git_available() -> bool {
+        Command::new("git").arg("--version").output().is_ok()
     }
 
     fn run_git(dir: &Path, args: &[&str]) {

--- a/crates/migration-tools/src/strangler.rs
+++ b/crates/migration-tools/src/strangler.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -54,17 +54,27 @@ impl Strangler {
     }
 
     pub fn diff_paths(&self, base: &str) -> Result<Vec<String>> {
+        let mut last_error = None;
         for separator in ["...", ".."] {
             let spec = format!("{base}{separator}HEAD");
             let output = Command::new("git")
                 .args(["diff", "--name-only", &spec])
                 .current_dir(&self.repo_root)
-                .output()?;
+                .output()
+                .with_context(|| format!("failed to run git diff for {spec}"))?;
             if output.status.success() {
                 return parse_paths(output.stdout);
             }
+            last_error = Some(format!(
+                "git diff --name-only {spec} failed with status {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
         }
-        Ok(Vec::new())
+        bail!(
+            "{}",
+            last_error.unwrap_or_else(|| "git diff failed without stderr".to_string())
+        )
     }
 
     pub fn tracked_paths(&self) -> Result<Vec<String>> {
@@ -150,7 +160,8 @@ fn normalize(path: &str) -> String {
 
 fn directory_size(path: &Path) -> std::io::Result<u64> {
     let mut total = 0;
-    for entry in walkdir::WalkDir::new(path).into_iter().flatten() {
+    for entry in walkdir::WalkDir::new(path) {
+        let entry = entry.map_err(std::io::Error::other)?;
         if entry.path().is_file() {
             total += entry.metadata()?.len();
         }
@@ -187,5 +198,65 @@ mod tests {
         ]);
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].legacy_root, "tools/py_ref_runner");
+    }
+
+    #[test]
+    fn size_report_marks_missing_roots() {
+        let config = StranglerConfig {
+            legacy_roots: vec!["missing/root".to_string()],
+            descriptions: HashMap::new(),
+        };
+        let strangler = Strangler::new(config, PathBuf::from("."));
+        let report = strangler.size_report();
+
+        assert_eq!(report.len(), 1);
+        assert_eq!(report[0].bytes, 0);
+        assert_eq!(report[0].status, "missing");
+    }
+
+    #[test]
+    fn diff_paths_reports_git_errors() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = StranglerConfig {
+            legacy_roots: vec!["legacy".to_string()],
+            descriptions: HashMap::new(),
+        };
+        let strangler = Strangler::new(config, temp.path().to_path_buf());
+
+        let error = strangler.diff_paths("origin/missing").unwrap_err();
+        assert!(error.to_string().contains("git diff --name-only"));
+    }
+
+    #[test]
+    fn diff_paths_reads_changed_files() {
+        let temp = tempfile::tempdir().unwrap();
+        run_git(temp.path(), &["init"]);
+        run_git(temp.path(), &["config", "user.email", "test@example.com"]);
+        run_git(temp.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(temp.path().join("README.md"), "initial\n").unwrap();
+        run_git(temp.path(), &["add", "README.md"]);
+        run_git(temp.path(), &["commit", "-m", "initial"]);
+        std::fs::create_dir_all(temp.path().join("legacy")).unwrap();
+        std::fs::write(temp.path().join("legacy/file.txt"), "legacy\n").unwrap();
+        run_git(temp.path(), &["add", "legacy/file.txt"]);
+        run_git(temp.path(), &["commit", "-m", "legacy"]);
+
+        let config = StranglerConfig {
+            legacy_roots: vec!["legacy".to_string()],
+            descriptions: HashMap::new(),
+        };
+        let strangler = Strangler::new(config, temp.path().to_path_buf());
+        let paths = strangler.diff_paths("HEAD~1").unwrap();
+
+        assert_eq!(paths, vec!["legacy/file.txt"]);
+    }
+
+    fn run_git(dir: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git {args:?} failed");
     }
 }


### PR DESCRIPTION
## Summary
- harden the migration tools workflow with least-privilege permissions, concurrency, and v5 GitHub actions
- make strangler diff checks fail loudly when git diff cannot resolve the requested base
- parse Cargo.toml with `toml` instead of substring matching for service discovery
- report walkdir traversal errors instead of silently dropping unreadable entries
- add fixture tests and minimal migration-tools README/CONTRIBUTING docs

## Verification
- `cargo fmt -p migration-tools --check`
- `cargo test -p migration-tools`
- `cargo clippy -p migration-tools --all-targets -- -D warnings`
- `cargo run -p migration-tools --bin openapi-extractor -- --root . --output-dir target/migration-tools/openapi`
- `cargo run -p migration-tools --bin strangler -- --mode diff --base origin/develop --fail-on-legacy`