### PR TITLE
ci(swe-bench): fix invalid job-level secrets gate

### DIFF
--- a/.github/workflows/swe-bench.yml
+++ b/.github/workflows/swe-bench.yml
@@ -26,10 +26,16 @@ jobs:
     name: Run SWE-Bench Evaluation
     runs-on: macos-latest
 
-    # Gate on API key availability
-    if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
-
     steps:
+      - name: Require ANTHROPIC_API_KEY secret
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::error::ANTHROPIC_API_KEY secret is not set. Configure it in repo settings before triggering this workflow."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -86,4 +92,4 @@ jobs:
 
       - name: Comment on workflow run
         run: |
-          cargo run -p mlx-bench --release -- report --latest --format table >> $GITHUB_STEP_SUMMARY
+          cargo run -p mlx-bench --release -- report --latest --format table >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Fixes #143 — \`swe-bench.yml\` was failing in 0s on every push to every branch because of a job-level \`if:\` referencing the \`secrets\` context:

\`\`\`yaml
# Gate on API key availability
if: \${{ secrets.ANTHROPIC_API_KEY != '' }}
\`\`\`

The \`secrets\` context isn't available in job-level \`if:\` expressions — only inside step \`run:\`/\`uses:\`/\`with:\` blocks. So GitHub Actions rejected the file on every event (not just \`workflow_dispatch\`), surfacing as a noisy failed run that masked real CI failures from readers scanning the workflows list.

## Fix

- Drop the job-level \`if:\`.
- Add a first-step \"Require ANTHROPIC_API_KEY secret\" guard that exits 1 with a clear \`::error::\` message if the secret is empty at runtime. Manual triggers without the secret configured now fail fast and loud at the gate instead of mid-evaluation with a cryptic Rust panic.
- Also quote \`\$GITHUB_STEP_SUMMARY\` in the final \`report\` step (\`SC2086\` shellcheck warning, called out in #143).

## Verification

- \`actionlint\` no longer flags either issue on this file. (Two remaining actionlint findings on \`swe-bench.yml\` are about \`actions/cache@v3\` and \`actions/upload-artifact@v3\` being too old — out of scope here; PR #142 bumps those.)
- \`python3 -c \"import yaml; yaml.safe_load(...)\"\` parses cleanly.
- The workflow is \`workflow_dispatch\` only, so true end-to-end verification is a manual trigger after merge. The next push to \`develop\` should no longer show a \`swe-bench.yml\` failed-run entry in the actions list.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)